### PR TITLE
Add potential solution for hover issue caused by listener on window

### DIFF
--- a/src/HookUseHover.js
+++ b/src/HookUseHover.js
@@ -1,5 +1,5 @@
 
-import React, { useRef, useEffect, useCallback, useContext, useState } from "react";
+import React, { useEffect, useCallback, useContext, useState } from "react";
 
 import useHover from "./hooks/useHover";
 import useSourceCode from "./hooks/useSourceCode";
@@ -11,12 +11,10 @@ import PageTitle from "./PageTitle";
 export default function HookUseHover()
 {
     const [domNode, setDomNode] = useState(null);
-    const elementRef = useRef();
-    // const elementRef = useCallback(node => {
-    //     setDomNode(node)
-    // });
-    const { hovered, setHovered } = useHover(elementRef);
-    //const { hovered, setHovered } = useHover(domNode);
+    const elementRef = useCallback(node => {
+        setDomNode(node)
+    });
+    const { hovered, setHovered } = useHover(domNode);
 
     const { t } = useContext(contextTranslate);
 

--- a/src/HookUseHover.js
+++ b/src/HookUseHover.js
@@ -1,5 +1,5 @@
 
-import React, { useRef, useEffect, useContext } from "react";
+import React, { useRef, useEffect, useCallback, useContext, useState } from "react";
 
 import useHover from "./hooks/useHover";
 import useSourceCode from "./hooks/useSourceCode";
@@ -9,11 +9,16 @@ import PageTitle from "./PageTitle";
 
 
 export default function HookUseHover()
-	{
-	const elementRef = useRef();
-  const { hovered, setHovered } = useHover(elementRef);
+{
+    const [domNode, setDomNode] = useState(null);
+    const elementRef = useRef();
+    // const elementRef = useCallback(node => {
+    //     setDomNode(node)
+    // });
+    const { hovered, setHovered } = useHover(elementRef);
+    //const { hovered, setHovered } = useHover(domNode);
 
-  const { t } = useContext(contextTranslate);
+    const { t } = useContext(contextTranslate);
 
 
 	// // Scroll to top after a delay for autoFocus:

--- a/src/hooks/useEventListener.js
+++ b/src/hooks/useEventListener.js
@@ -28,6 +28,7 @@ export default function useEventListener(
 
 		const handler = e => callbackRef.current(e);
 		// Default element is window:
+            console.count("---Jamal: Event listener added!")
 		element.addEventListener(eventType, handler);
 
 		// Cleanup previous listeners:

--- a/src/hooks/useHover.js
+++ b/src/hooks/useHover.js
@@ -7,10 +7,8 @@ export default function useHover(elementRef)
 {
     const [hovered, setHovered] = useState(false);
 
-    useEventListener("mouseover", () => setHovered(true), elementRef.current);
-    useEventListener("mouseout", () => setHovered(false), elementRef.current);
-    // useEventListener("mouseover", () => setHovered(true), elementRef);
-    // useEventListener("mouseout", () => setHovered(false), elementRef);
+    useEventListener("mouseover", () => setHovered(true), elementRef);
+    useEventListener("mouseout", () => setHovered(false), elementRef);
 
     return { hovered, setHovered };
 }

--- a/src/hooks/useHover.js
+++ b/src/hooks/useHover.js
@@ -4,11 +4,13 @@ import useEventListener from "./useEventListener";
 
 
 export default function useHover(elementRef)
-	{
-	const [hovered, setHovered] = useState(false);
+{
+    const [hovered, setHovered] = useState(false);
 
-	useEventListener("mouseover", () => setHovered(true), elementRef.current);
-	useEventListener("mouseout", () => setHovered(false), elementRef.current);
+    useEventListener("mouseover", () => setHovered(true), elementRef.current);
+    useEventListener("mouseout", () => setHovered(false), elementRef.current);
+    // useEventListener("mouseover", () => setHovered(true), elementRef);
+    // useEventListener("mouseout", () => setHovered(false), elementRef);
 
-  return { hovered, setHovered };
-	}
+    return { hovered, setHovered };
+}


### PR DESCRIPTION
Current hypothesis and solution:

The `useHover` hook is not being called after the DOM element is mounted with `useRef`. It is being called before it is mounted so the event listeners are being added to the default `element = window` in the `useEventListener` hook and not the expected DOM object. That is why the `mouseover` event is being triggered at inappropriate times.

When the `mouseover` event on the `window` is triggered it then leads to a state change -> rerender -> new `useEffect` call in `useEventListener` but this time it has the mounted `elementRef.current` value.

The solution provided in the comments solves this problem by using a state and a ref callback function to monitor when the DOM element is mounted and to trigger the rerender immediately with the event listeners added to the correct DOM element and not the default `element = window`.
